### PR TITLE
feat: add authorization header to csv upload file

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -31,8 +31,14 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
 
   const uploadFile = async (e: any) => {
       // Get the presigned URL
+      const token = localStorage.getItem('authorization_token');
       const response = await axios({
         method: 'GET',
+        headers: {
+          ...(token ? {
+            'Authorization': `Basic ${token}`
+          }: {})
+        },
         url,
         params: {
           name: encodeURIComponent(file.name)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,10 @@ axios.interceptors.response.use(
   function(error) {
     if (error?.response?.status === 400) {
       alert(error.response.data?.data);
+    } else if (error?.response?.status === 403) {
+      alert(error.response.data?.Message);
+    } else if (error?.response?.status === 401) {
+      alert(error.response.data?.message);
     }
 
     return Promise.reject(error?.response ?? error);


### PR DESCRIPTION
updated client application to send `Authorization: Basic authorization_token` header on import. 

[FE app](https://d1aozobrzk7at4.cloudfront.net/) 